### PR TITLE
Turn off transmitter in straight key mode

### DIFF
--- a/src/RebelAllianceMod_v2_2/RebelAllianceMod_v2_2.pde
+++ b/src/RebelAllianceMod_v2_2/RebelAllianceMod_v2_2.pde
@@ -582,7 +582,7 @@ void TX_routine()
             TX_key = digitalRead(TX_Dit);
         } while (TX_key == LOW);         // was high 
 
-        TX_off;
+        TX_off();
         loopStartTime = millis();       //Reset the Timer for this loop
     }
   } 


### PR DESCRIPTION
On the email list, a bug with straight key mode was noted.  The issue was discovered to be missing parentheses on a call to TX_Off.
