### PR TITLE
Only flash LED every four steps for correct 100/1K/10K flashes

### DIFF
--- a/src/RebelAllianceMod_v2_3/RebelAllianceMod_v2_3.pde
+++ b/src/RebelAllianceMod_v2_3/RebelAllianceMod_v2_3.pde
@@ -167,6 +167,7 @@ int encoder0PinALast            = LOW;
 int encoder0PinBLast            = LOW;
 int n                           = LOW;
 int m                           = LOW;
+int step_counter                = 0;          // Flash LED every 4 steps
 
 // frequency vaiables and memory
 const long meter_40             = 16.03e6;      // IF + Band frequency, 
@@ -517,8 +518,13 @@ void Encoder()
 void Frequency_up()
 { 
     frequency = frequency + frequency_step;
+    step_counter += 1;
     
-    Step_Flash();
+    if (step_counter % 4 == 0)
+    {
+        step_counter = 0;
+        Step_Flash();
+    }
     
 #ifndef FEATURE_BANDSWITCH
     bsm = digitalRead(Band_Select); 
@@ -533,8 +539,13 @@ void Frequency_up()
 void Frequency_down()
 { 
     frequency = frequency - frequency_step;
+    step_counter -= 1;
     
-    Step_Flash();
+    if (step_counter % 4 == 0)
+    {
+        step_counter = 0;
+        Step_Flash();
+    }
     
 #ifndef FEATURE_BANDSWITCH
     bsm = digitalRead(Band_Select); 


### PR DESCRIPTION
With the improved encoder resolution, the LED would flash every 25 Hz/250 Hz/2.5 KHz step which is too frequently to be helpful. The patch flashes the LED only every fourth frequency change, corresponding to the original 100Hz/1kHz/10kHz step sizes.
