### PR TITLE
Flash LED when beeping sidetone

### DIFF
--- a/src/RebelAllianceMod_v2_3/RebelAllianceMod_v2_3.pde
+++ b/src/RebelAllianceMod_v2_3/RebelAllianceMod_v2_3.pde
@@ -833,9 +833,11 @@ void announce(char *str){
 
 void beep(int LENGTH) {
   digitalWrite(Side_Tone, HIGH);
+  digitalWrite(Band_End_Flash_led, HIGH);
   delay(LENGTH);
   for (int i=0; i <= 10e3; i++);       // delay to equel with TX speed
   digitalWrite(Side_Tone, LOW);
+  digitalWrite(Band_End_Flash_led, LOW);
   delay(ditTime) ;
 }
 


### PR DESCRIPTION
This flashes the band-end LED when announcing with the sidetone.  It provides improved visual feedback which can be especially helpful when the ChipKit is powered from USB and the audio is not powered on. It probably isn't visually decodable above 20 WPM, but some people might be able to use it faster.
